### PR TITLE
Make the playground preview window scrollable

### DIFF
--- a/src/components/Preview/style.css
+++ b/src/components/Preview/style.css
@@ -3,4 +3,5 @@
   max-width: 500px;
   flex-basis: 500px;
   padding: 0 1em 0 0.5em;
+  overflow: scroll;
 }


### PR DESCRIPTION
When I was using the playground, I entered a lot of code, which made the output of the preview page exceed the scope of the screen display. At this time, it should be scrollable, but no, I noticed the container (that is, the playground-sidebar class) There is no overflow attribute above, so I added it.

before:

<img width="1118" alt="image" src="https://user-images.githubusercontent.com/10683193/207756041-61e6df1a-6eed-4736-bdce-296b87439166.png">

after:

<img width="1107" alt="image" src="https://user-images.githubusercontent.com/10683193/207756075-1b0ad5b4-1d7a-498a-9689-eedbbf69a8b2.png">
